### PR TITLE
Fix Italian translation

### DIFF
--- a/jpsxdec/src/jpsxdec/i18n/Translations_it.properties
+++ b/jpsxdec/src/jpsxdec/i18n/Translations_it.properties
@@ -1,6 +1,6 @@
 # jPSXdec Translations
 # Copyright (c) 2015-2019
-# Michael Sabin, VÌctor Gonz·lez, Sergi Medina, Gianluigi "Infrid" Cusimano
+# Michael Sabin, V√≠ctor Gonz√°lez, Sergi Medina, Gianluigi "Infrid" Cusimano
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1269,7 +1269,7 @@ VID_IMG_SEQ_MDEC_DESCRIPTION=Sequenza immagini\: mdec
 VID_IMG_SEQ_MDEC_COMMAND=mdec
 
 #[VideoFormat.java]
-VID_AVI_JYUV_DESCRIPTION=AVI\: YUV con raggio 0-255
+VID_AVI_JYUV_DESCRIPTION=AVI\: YUV con intervallo [0-255]
 
 VID_AVI_JYUV_COMMAND=avi\:jyuv
 
@@ -1284,7 +1284,7 @@ VID_IMG_SEQ_BS_DESCRIPTION=Sequenza immagini\: bitstream
 VID_IMG_SEQ_BS_COMMAND=bs
 
 #[VideoFormat.java]
-VID_AVI_YUV_DESCRIPTION=AVI\: YUV con raggio 0-255
+VID_AVI_YUV_DESCRIPTION=AVI\: YUV con intervallo [16-235]
 
 VID_AVI_YUV_COMMAND=avi\:yuv
 

--- a/jpsxdec/src/jpsxdec/i18n/Translations_it.properties
+++ b/jpsxdec/src/jpsxdec/i18n/Translations_it.properties
@@ -1269,7 +1269,7 @@ VID_IMG_SEQ_MDEC_DESCRIPTION=Sequenza immagini\: mdec
 VID_IMG_SEQ_MDEC_COMMAND=mdec
 
 #[VideoFormat.java]
-VID_AVI_JYUV_DESCRIPTION=AVI\: YUV con intervallo [0-255]
+VID_AVI_JYUV_DESCRIPTION=AVI\: YUV intervallo [0-255]
 
 VID_AVI_JYUV_COMMAND=avi\:jyuv
 
@@ -1284,7 +1284,7 @@ VID_IMG_SEQ_BS_DESCRIPTION=Sequenza immagini\: bitstream
 VID_IMG_SEQ_BS_COMMAND=bs
 
 #[VideoFormat.java]
-VID_AVI_YUV_DESCRIPTION=AVI\: YUV con intervallo [16-235]
+VID_AVI_YUV_DESCRIPTION=AVI\: YUV intervallo [16-235]
 
 VID_AVI_YUV_COMMAND=avi\:yuv
 


### PR DESCRIPTION
Hi, I fixed a rather annoying translation error where both YUV formats were listed with dynamic range of 0-255.

Before
<img width="935" height="631" alt="image" src="https://github.com/user-attachments/assets/70725a87-00c9-4991-b0d6-0af4ff7a8e96" />

After
<img width="946" height="623" alt="image" src="https://github.com/user-attachments/assets/627ee81e-72ee-44ee-9683-5faca8cac0f4" />
